### PR TITLE
Support multiple environments through environment variable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,22 @@
 PATH
   remote: .
   specs:
-    contentful-migrations (0.1.0)
-      contentful-management (~> 1.10.1)
+    contentful-migrations (0.1.1)
+      contentful-management (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    byebug (10.0.0)
-    contentful-management (1.10.1)
+    byebug (10.0.2)
+    coderay (1.1.2)
+    contentful-management (2.6.0)
       http (> 1.0, < 3.0)
       json (~> 1.8)
       multi_json (~> 1)
     diff-lcs (1.3)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http (2.2.2)
       addressable (~> 2.3)
@@ -27,22 +28,26 @@ GEM
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
     json (1.8.6)
+    method_source (0.9.2)
     multi_json (1.13.1)
-    public_suffix (3.0.2)
-    rake (12.3.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    public_suffix (3.0.3)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
@@ -54,8 +59,9 @@ DEPENDENCIES
   bundler (~> 1.16)
   byebug (~> 10.0.0)
   contentful-migrations!
+  pry
   rake (~> 12.3.0)
   rspec (~> 3.6)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/contentful-migrations.gemspec
+++ b/contentful-migrations.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'contentful-management', '~> 1.10.1'
+  spec.add_dependency 'contentful-management', '~> 2.6'
 
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3.0'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -22,21 +22,23 @@ module ContentfulMigrations
       new(parse_options(args)).pending
     end
 
-    attr_reader :migrations_path, :access_token, :space_id, :client, :space,
+    attr_reader :migrations_path, :access_token, :space_id, :client, :space, :env_id,
                 :migration_content_type_name, :logger
 
     def initialize(migrations_path:,
                    access_token:,
                    space_id:,
                    migration_content_type_name:,
-                   logger:)
+                   logger:,
+                   env_id: nil)
       @migrations_path = migrations_path
       @access_token = access_token
       @logger = logger
       @space_id = space_id
       @migration_content_type_name = migration_content_type_name
       @client = Contentful::Management::Client.new(access_token)
-      @space = @client.environments(space_id).find(ENV['CONTENTFUL_ENV'] || 'master')
+      @env_id = env_id || ENV['CONTENTFUL_ENV'] || 'master'
+      @space = @client.environments(space_id).find(@env_id)
       validate_options
     end
 

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -36,7 +36,7 @@ module ContentfulMigrations
       @space_id = space_id
       @migration_content_type_name = migration_content_type_name
       @client = Contentful::Management::Client.new(access_token)
-      @space = @client.spaces.find(space_id)
+      @space = @client.environments(space_id).find(ENV['CONTENTFUL_ENV'] || 'master')
       validate_options
     end
 

--- a/spec/lib/contentful_migrations/migrator_spec.rb
+++ b/spec/lib/contentful_migrations/migrator_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe ContentfulMigrations::Migrator do
 
       before do
         expect(Contentful::Management::Client).to receive(:new).and_return(client)
-        expect(client).to receive(:spaces).and_return(spaces)
-        expect(spaces).to receive(:find).with('space_id').and_return(space)
+        expect(client).to receive(:environments).with('space_id').and_return(space)
+        expect(space).to receive(:find).with('master').and_return(space)
         allow(subject).to receive(:migration_content_type).and_return(migration_content_type)
       end
 

--- a/spec/lib/contentful_migrations/migrator_spec.rb
+++ b/spec/lib/contentful_migrations/migrator_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe ContentfulMigrations::Migrator do
       access_token: 'access_token',
       space_id: 'space_id',
       migration_content_type_name: ContentfulMigrations::MigrationContentType::DEFAULT_MIGRATION_CONTENT_TYPE,
-      logger: logger }
+      logger: logger,
+      env_id: 'master' }
   end
 
   describe '#initialize' do
@@ -60,6 +61,7 @@ RSpec.describe ContentfulMigrations::Migrator do
       expect(migrator.access_token).to eq('access_token')
       expect(migrator.space_id).to eq('space_id')
       expect(migrator.migration_content_type_name).to eq('migrations')
+      expect(migrator.env_id).to eq('master')
     end
     it 'raises error when invalid path' do
       expect do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'contentful_migrations'
+require 'pry'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Since the last release of this gem, Contentful has been updated to support multiple environments within a single space. This PR upgrades contentful-management.rb to the latest and adds multi-environment support.

Fixed the broken spec as a result, but did not bump gem version number.