### PR TITLE
Implement pagination for migration records

### DIFF
--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -97,7 +97,7 @@ module ContentfulMigrations
     end
 
     def load_migrated
-      migration_content_type.entries.all.map { |m| m.version.to_i }
+      migration_content_type.entries.all(limit: 1000).map { |m| m.version.to_i }
     end
 
     def migrations(paths)


### PR DESCRIPTION
This PR implements pagination logic for Contentful's API so that we get all migration records, every time the script is run. 