### PR TITLE
Lock http to 4.1.1 due to HTTP::ConnectionError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    contentful-migrations (0.1.3)
+    contentful-migrations (0.1.4)
       contentful-management (~> 2.6)
+      http (~> 4.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -11,34 +12,29 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     byebug (10.0.2)
     coderay (1.1.2)
-    contentful-management (2.11.0)
+    contentful-management (2.12.0)
       http (> 1.0, < 5.0)
       json (>= 1.8, < 3.0)
       multi_json (~> 1)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.11.1)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
-    http (4.2.0)
+    http (4.1.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
-      http-parser (~> 1.2.0)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (2.1.1)
-    http-parser (1.2.1)
-      ffi-compiler (>= 1.0, < 2.0)
-    json (2.2.0)
+    http-form_data (2.3.0)
+    http_parser.rb (0.6.0)
+    json (2.3.0)
     method_source (0.9.2)
     multi_json (1.14.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -69,4 +65,4 @@ DEPENDENCIES
   rspec (~> 3.6)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/contentful-migrations.gemspec
+++ b/contentful-migrations.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'contentful-management', '~> 2.6'
+  spec.add_dependency 'http', '~> 4.1.1'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lib/contentful_migrations/version.rb
+++ b/lib/contentful_migrations/version.rb
@@ -1,3 +1,3 @@
 module ContentfulMigrations
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end


### PR DESCRIPTION
The latest version of the HTTP gem is throwing the following error... 

```
HTTP::ConnectionError: error reading from socket: Could not parse data
```

This PR locks that dependency to the last working version per [this thread](https://github.com/contentful/contentful-management.rb/issues/210). 