### PR TITLE
Move rake task loading into a Railtie; inherit the rails environment in said task

### DIFF
--- a/lib/contentful_migrations.rb
+++ b/lib/contentful_migrations.rb
@@ -6,4 +6,4 @@ require 'contentful_migrations/migration_proxy'
 require 'contentful_migrations/migration'
 require 'contentful_migrations/migrator'
 
-# load 'tasks/contentful_migrations.rake' if defined?(Rails)
+require 'contentful_migrations/railtie' if defined?(Rails::Railtie)

--- a/lib/contentful_migrations.rb
+++ b/lib/contentful_migrations.rb
@@ -6,4 +6,4 @@ require 'contentful_migrations/migration_proxy'
 require 'contentful_migrations/migration'
 require 'contentful_migrations/migrator'
 
-load 'tasks/contentful_migrations.rake' if defined?(Rails)
+# load 'tasks/contentful_migrations.rake' if defined?(Rails)

--- a/lib/contentful_migrations/railtie.rb
+++ b/lib/contentful_migrations/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ContentfulMiagrations
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load File.join(File.dirname(__FILE__), '..', 'tasks', 'contentful_migrations.rake')
+    end
+
+    generators do
+      require_relative "../generators/contentful_migration_generator"
+    end
+  end
+end

--- a/lib/contentful_migrations/railtie.rb
+++ b/lib/contentful_migrations/railtie.rb
@@ -7,7 +7,7 @@ module ContentfulMiagrations
     end
 
     generators do
-      require_relative "../generators/contentful_migration_generator"
+      require_relative '../generators/contentful_migration/contentful_migration_generator'
     end
   end
 end

--- a/lib/tasks/contentful_migrations.rake
+++ b/lib/tasks/contentful_migrations.rake
@@ -1,17 +1,17 @@
 require 'contentful_migrations'
 namespace :contentful_migrations do
   desc 'Migrate the contentful space, runs all pending migrations'
-  task :migrate, [:contentful_space]  do |_t, _args|
+  task migrate: :environment do |_t, _args|
     ContentfulMigrations::Migrator.migrate
   end
 
   desc 'Rollback previous contentful migration'
-  task :rollback, [:contentful_space] do |_t, _args|
+  task rollback: :environment do |_t, _args|
     ContentfulMigrations::Migrator.rollback
   end
 
   desc 'List any pending contentful migrations'
-  task :pending, [:contentful_space]  do |_t, _args|
+  task pending: :environment  do |_t, _args|
     ContentfulMigrations::Migrator.pending
   end
 end


### PR DESCRIPTION
I was getting an `NoMethodError` due to the gem just loading the rake task if `Rails` was defined.  This PR addresses that by creating a `Railtie` class where generators and rake tasks can be explicitly defined in the rails app.

Additionally, when running the `contentful_migrations:migrate` task I was getting errors indicating that the rails environment hadn't been loaded properly, so I've added that as a pre-requisite for the task to run.